### PR TITLE
Allow custom file format when editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,19 +56,31 @@ td group global preset
 Check out the [`api`](https://github.com/darrikonn/td-cli/blob/master/API.md).
 
 ## Configuring
-### Database name
-Your database instance will be located in your home directory (`~/`).
-By default it'll be named `todo`.
+The location of your todos and your configuration will depend on these environment variables (in this order):
+1. **TD_CLI_HOME**: determines where your `todo.db` and `todo.cfg` file will live
+2. **XDG_CONFIG_HOME**: a fallback if `$TD_CLI_HOME` is not set
+3. **HOME**: a fallback if `$XDG_CONFIG_HOME` is not set. If `$HOME` is used; all files will be transformed to a dotfile, i.e.`~/.todo.db` and `~/.todo.cfg`.
 
-You can change your database name by specifying `database_name` in your `~/.td.cfg` file:
+### Database name
+Your database instance will be located in in the before-mentioned configuration directory.
+By default the database will be named `todo`.
+
+You can change your database name by specifying `database_name` in your `$TD_CLI_HOME/.todo.cfg` file:
 ```cfg
 [settings]
 database_name: something_else
 ```
-This results in a database instance at `~/.something_else.db`
+This results in a database instance at `$TD_CLI_HOME/.something_else.db`
+
+### Format
+You can specify your preferred format of your todo's details via the format config keyword:
+```cfg
+format: md
+```
+This would result in the `.md` (Markdown) file extension when editing a todo. This allows you to use the power of your editor to e.g. syntax highlight the details, and etc.
 
 ### Editor
-When editing a todo, `td <id> edit`, you can both specify the todo's `name` and the todo's `details`. If no option is specified, your todo will be opened in `vi` by default (your `environement EDITOR` will override this) where you can edit the todo's details. You can change the default editor by updating your config:
+When editing a todo, `td <id> edit`, you can both specify the todo's `name` and the todo's `details` via options (see `td <id> edit --help`). If no option is specified, your todo will be opened in `vi` by default (your `environement EDITOR` will override this) where you can edit the todo's details. You can change the default editor by updating your config:
 ```cfg
 [settings]
 editor: nvim
@@ -86,8 +98,8 @@ If no group is provided, `td` will list from the current default group. You can 
 td g my-group preset
 ```
 
-However, there's an option to set the default group per git project (this is not possible from the root config `~/.td.cfg`).
-In the root of your git project, you can create a `.td.cfg` config file to specify what group to default on (this will override the global default group):
+However, there's an option to set the default group per git project (this is not possible from the root config `$TD_CLI_HOME/.todo.cfg`).
+In any root of your projects, you can create a `.td.cfg` config file to specify what group to default on (this will override the global default group):
 ```cfg
 [settings]
 group: my-group

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="td-cli",
-    version="1.3.0",
+    version="2.0.0",
     description="A todo command line manager",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/todo/services/__init__.py
+++ b/todo/services/__init__.py
@@ -3,7 +3,7 @@ import sqlite3
 from pathlib import Path
 from urllib.request import pathname2url
 
-from todo.settings import config
+from todo.settings import config, get_home
 
 from .group import GroupService
 from .todo import TodoService
@@ -27,7 +27,10 @@ class Service:
         self.cursor.execute("PRAGMA foreign_keys = ON")
 
     def _get_database_path(self):
-        return os.path.expanduser(Path("~/.{}.db".format(config["database_name"])))
+        home_dir, prefix = get_home()
+        database_name = f"{prefix}{config['database_name']}.db"
+
+        return os.path.expanduser(Path.joinpath(home_dir, database_name))
 
     def _initialise_database(self, db_uri):
         self.connection = sqlite3.connect(db_uri, uri=True)

--- a/todo/services/group.py
+++ b/todo/services/group.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from todo.exceptions import TodoException
 from todo.services.base import GLOBAL, BaseService
 from todo.settings import config, get_project_config
@@ -116,7 +118,7 @@ class GroupService(BaseService):
                     "{bold}<Group: %s>{reset} does not exist, falling back to currently active group"
                     % config["group"],
                     "Your config file at {bold}%s{reset} tries to\noverride the "
-                    % (get_project_config() or "~")
+                    % (get_project_config(Path.cwd()) or "~")
                     + "default group with `{bold}%s{reset}`, but " % config["group"]
                     + "{bold}<Group: %s>{reset} does not exist." % config["group"],
                     "WARNING",

--- a/todo/settings.py
+++ b/todo/settings.py
@@ -2,6 +2,9 @@ import configparser
 import os
 from functools import lru_cache
 from pathlib import Path
+from typing import Tuple
+
+from todo.exceptions import TodoException
 
 CONFIG_SECTION = "settings"
 DEFAULT_CONFIG = {"database_name": "todo", "editor": "vi", "group": None, "format": "tmp"}
@@ -24,6 +27,37 @@ def get_project_config(filepath):
 
 
 @lru_cache()
+def get_home() -> Tuple[Path, str]:
+    # try from TD_CLI_HOME environment variable
+    td_cli_env_dir = os.environ.get("TD_CLI_HOME")
+    if td_cli_env_dir:
+        td_cli_env_dir = Path.expanduser(Path(td_cli_env_dir))
+        if not Path.exists(td_cli_env_dir):
+            raise TodoException(
+                f'TD_CLI_HOME environment variable set to "{td_cli_env_dir}", but directory does not exist'
+            )
+
+        return (td_cli_env_dir, "")
+
+    # try from XDG_CONFIG_HOME environment variable
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_config_home:
+        xdg_config_home = Path.expanduser(Path(xdg_config_home))
+        if not Path.exists(xdg_config_home):
+            raise TodoException(
+                f'XDG_CONFIG_HOME environment variable set to "{xdg_config_home}", but directory does not exist'
+            )
+
+        config_dir = Path.joinpath(xdg_config_home, "td-cli")
+        if not config_dir:
+            Path.mkdir(config_dir)
+        return (config_dir, "")
+
+    # fallback to home directory
+    return (Path.home(), ".")
+
+
+@lru_cache()
 def _get_config():
     settings = DEFAULT_CONFIG
 
@@ -40,7 +74,8 @@ def _get_config():
         settings["editor"] = environment_editor
 
     # from root config
-    config_file = Path.joinpath(Path.home(), ".config", "td-cli", "td.cfg")
+    home_dir, prefix = get_home()
+    config_file = Path.joinpath(home_dir, f"{prefix}todo.cfg")
     if Path.exists(config_file):
         _update_from_config(config_file)
 

--- a/todo/settings.py
+++ b/todo/settings.py
@@ -2,7 +2,7 @@ import configparser
 import os
 from functools import lru_cache
 from pathlib import Path
-from typing import Tuple
+from typing import Optional, Tuple
 
 from todo.exceptions import TodoException
 
@@ -29,9 +29,9 @@ def get_project_config(filepath):
 @lru_cache()
 def get_home() -> Tuple[Path, str]:
     # try from TD_CLI_HOME environment variable
-    td_cli_env_dir = os.environ.get("TD_CLI_HOME")
-    if td_cli_env_dir:
-        td_cli_env_dir = Path.expanduser(Path(td_cli_env_dir))
+    td_cli_env: Optional[str] = os.environ.get("TD_CLI_HOME")
+    if td_cli_env:
+        td_cli_env_dir: Path = Path.expanduser(Path(td_cli_env))
         if not Path.exists(td_cli_env_dir):
             raise TodoException(
                 f'TD_CLI_HOME environment variable set to "{td_cli_env_dir}", but directory does not exist'
@@ -40,16 +40,16 @@ def get_home() -> Tuple[Path, str]:
         return (td_cli_env_dir, "")
 
     # try from XDG_CONFIG_HOME environment variable
-    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+    xdg_config_home: Optional[str] = os.environ.get("XDG_CONFIG_HOME")
     if xdg_config_home:
-        xdg_config_home = Path.expanduser(Path(xdg_config_home))
-        if not Path.exists(xdg_config_home):
+        xdg_config_home_dir: Path = Path.expanduser(Path(xdg_config_home))
+        if not Path.exists(xdg_config_home_dir):
             raise TodoException(
                 f'XDG_CONFIG_HOME environment variable set to "{xdg_config_home}", but directory does not exist'
             )
 
-        config_dir = Path.joinpath(xdg_config_home, "td-cli")
-        if not config_dir:
+        config_dir = Path.joinpath(xdg_config_home_dir, "td-cli")
+        if not config_dir.exists():
             Path.mkdir(config_dir)
         return (config_dir, "")
 

--- a/todo/settings.py
+++ b/todo/settings.py
@@ -4,7 +4,7 @@ from functools import lru_cache
 from pathlib import Path
 
 CONFIG_SECTION = "settings"
-DEFAULT_CONFIG = {"database_name": "todo", "editor": "vi", "group": None}
+DEFAULT_CONFIG = {"database_name": "todo", "editor": "vi", "group": None, "format": "tmp"}
 EXAMPLE_CONFIG = """[settings]
 group: {group}
 """

--- a/todo/utils/__init__.py
+++ b/todo/utils/__init__.py
@@ -5,13 +5,15 @@ from subprocess import call
 
 from pkg_resources import get_distribution
 
+from todo.settings import config
+
 
 def generate_random_int():
     return "%06i" % random.randrange(10 ** 6)
 
 
 def get_user_input(editor, initial_message=b""):
-    with tempfile.NamedTemporaryFile(suffix=".tmp") as tf:
+    with tempfile.NamedTemporaryFile(suffix=f".{config['format']}") as tf:
         tf.write(initial_message)
         tf.flush()
         call([editor, "+set backupcopy=yes", tf.name])


### PR DESCRIPTION
Implements https://github.com/darrikonn/td-cli/issues/13 and https://github.com/darrikonn/td-cli/issues/16

Need to bump major version since the uncluttering might break in cases where `XDG_CONFIG_HOME` is set (for most Linux users).

- [x] Update README.md