### PR TITLE
Fix editing todos

### DIFF
--- a/todo/utils/__init__.py
+++ b/todo/utils/__init__.py
@@ -4,9 +4,7 @@ import shlex
 import subprocess
 import tempfile
 from importlib.metadata import PackageNotFoundError, version
-from os import (
-    get_terminal_size as os_get_terminal_size,
-)
+from os import get_terminal_size as os_get_terminal_size
 
 from todo.settings import config
 


### PR DESCRIPTION
Hi,

this should fix #54.

When calling

`td <id> e`

a PermissionDenied error prevented the editing of the file, because the file descriptor was still open.

Also tried it on macOS.

Additionally `+set backupcopy=yes` is only passed to programs that include `vim` in there name, e.g. `gvim` or `nvim`.

Hope that's fine, I've tried to keep the style.

Best regards,
patchninja42