### PR TITLE
Fix group list todos

### DIFF
--- a/todo/parser/subparsers/group.py
+++ b/todo/parser/subparsers/group.py
@@ -75,6 +75,14 @@ class GroupParser(BaseParser):
             help="filter by uncompleted todos",
         )
         list_parser.add_argument(
+            "--raw",
+            "-r",
+            dest="raw",
+            nargs=0,
+            action=set_value(True),
+            help="only show todos",
+        )
+        list_parser.add_argument(
             "--interactive", "-i", action="store_true", help="toggle interactive mode"
         )
         list_parser.set_defaults(command=COMMANDS.GET_GROUP)


### PR DESCRIPTION
Hi,

this should fix #55.

When calling

`td g test ls -v`

it fails with

```
Exception:
'Namespace' object has no attribute 'raw'
```

The problem was, that the parameter was not defined in this case.

Now it can be passed to this call and we can get a raw list of todos or a list of todos with extra context.

Hope that works out.

Best regards,
patchninja42